### PR TITLE
fix: 카카오 로그인 serializer로 넘겨주는 데이터 추가

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -111,7 +111,7 @@ def kakao_callback(request):
             'refresh_token': refresh_token,
             'accept_json': accept_json,             
         }
-        print(data)
+        # print(data)
         serializer = KakaoLoginSerializer(data)
         
         return JsonResponse(serializer.data)
@@ -136,9 +136,10 @@ def kakao_callback(request):
             'nickname': nickname,
             'profile_img': profile_img,
             'access_token': access_token,
-            'refresh_token': refresh_token,            
+            'refresh_token': refresh_token,
+            'accept_json': accept_json,             
         }
-        print(data)
+        # print(data)
         serializer = KakaoLoginSerializer(data)
 
         return JsonResponse(serializer.data)


### PR DESCRIPTION
기존의 key값(accept_json)도 같이 넘겨주는 로직으로 수정